### PR TITLE
src/LoRa-RP2040.cpp: reset the payload length in beginPacket.

### DIFF
--- a/src/LoRa-RP2040.cpp
+++ b/src/LoRa-RP2040.cpp
@@ -172,7 +172,7 @@ int LoRaClass::beginPacket(int implicitHeader)
   
   // reset FIFO address and paload length
   writeRegister(REG_FIFO_ADDR_PTR, 0);
-  // writeRegister(REG_PAYLOAD_LENGTH, 0);
+  writeRegister(REG_PAYLOAD_LENGTH, 0);
 
   return 1;
 }


### PR DESCRIPTION
Hi!

First of all, thank you for the library.

The payload length must be set to 0 at beginPacket(), otherwise sending multiple packet will accumulate the packet size. E.g.: if you send 5x packet with length 5, then the packet lengths will be 5, 10, 15, 20, ...
