### PR TITLE
LoRaClass::onReceive vs parsePacket

### DIFF
--- a/src/LoRa-RP2040.cpp
+++ b/src/LoRa-RP2040.cpp
@@ -227,6 +227,7 @@ int LoRaClass::parsePacket(int size)
 
   // clear IRQ's
   writeRegister(REG_IRQ_FLAGS, irqFlags);
+  writeRegister(REG_IRQ_FLAGS, irqFlags);
   
   if ((irqFlags & IRQ_RX_DONE_MASK) && (irqFlags & IRQ_PAYLOAD_CRC_ERROR_MASK) == 0) {
     // received a packet

--- a/src/LoRa-RP2040.cpp
+++ b/src/LoRa-RP2040.cpp
@@ -673,6 +673,7 @@ void LoRaClass::handleDio0Rise()
 
   // clear IRQ's
   writeRegister(REG_IRQ_FLAGS, irqFlags);
+  writeRegister(REG_IRQ_FLAGS, irqFlags);
 
   if ((irqFlags & IRQ_PAYLOAD_CRC_ERROR_MASK) == 0) {
 


### PR DESCRIPTION
Hi @akshayabali,

I managed to fix both of my issues.

The clue for the packet duplication was from this issue: https://github.com/sandeepmistry/arduino-LoRa/issues/463
The same thing helped for the onReceive callback.

Probably there is a better way to fix this issues, I'm not sure why I need to write that register twice.