### PR TITLE
Increase default SPI speed from 12.5Khz to 2Mhz

### DIFF
--- a/src/LoRa-RP2040.cpp
+++ b/src/LoRa-RP2040.cpp
@@ -100,7 +100,7 @@ int LoRaClass::begin(long frequency)
 
 
   // start SPI
-  spi_init(SPI_PORT, 12500);
+  spi_init(SPI_PORT, 2000000);
   gpio_set_function(PIN_MISO, GPIO_FUNC_SPI);
   gpio_set_function(PIN_SCK, GPIO_FUNC_SPI);
   gpio_set_function(PIN_MOSI, GPIO_FUNC_SPI);


### PR DESCRIPTION
Title says it all. I spent a few hours banging my head against the wall trying to figure out why there was such a high delay between one LoRa module sending a packet, and the other one fully processing it.

**Turns out the default SPI init frequency in this library is 12500Hz (12.5KHz), which in my opinion is unreasonably low, resulting in 5ms per character transferred from the packet queue.**

2MHz is a pretty standard SPI frequency, and I tested my modules with 10MHz no problem, so I believe changing the default to a safe 2MHz would be good.

I am aware of `LoRaClass::setSPIFrequency` but I think that the default should be more reasonable.

Thanks for reviewing this.